### PR TITLE
C-Extension + cm2 fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = lib/fadec
 	url = https://github.com/aengelke/fadec.git
 	branch = wip/encode
+[submodule "lib/frvdec"]
+	path = lib/frvdec
+	url = https://git.sr.ht/~aengelke/frvdec

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,19 @@ ExternalProject_Add(fadec
         TEST_COMMAND meson test -v
         BUILD_BYPRODUCTS ${FADEC_BYPRODUCTS})
 
+set(FRVDEC_PATH_PREFIX lib/frvdec)
+set(FRVDEC_BYPRODUCTS
+        ${FRVDEC_PATH_PREFIX}/${CMAKE_STATIC_LIBRARY_PREFIX}fadec${CMAKE_STATIC_LIBRARY_SUFFIX})
+ExternalProject_Add(frvdec
+        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${FRVDEC_PATH_PREFIX}
+        BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${FRVDEC_PATH_PREFIX}
+        CONFIGURE_COMMAND CFLAGS=-fno-stack-protector meson --buildtype ${MESON_BUILD_TYPE} ${CMAKE_CURRENT_SOURCE_DIR}/${FRVDEC_PATH_PREFIX}
+        BUILD_COMMAND ninja -v
+        INSTALL_COMMAND ""
+        UPDATE_COMMAND "pwd" #dummy so cmake always tries to update the subproject
+        TEST_COMMAND meson test -v
+        BUILD_BYPRODUCTS ${FRVDEC_BYPRODUCTS})
+
 #Will always be regenerated
 add_custom_target(
         version
@@ -152,6 +165,19 @@ add_dependencies(test fadecLib version)
 
 target_link_libraries("translator" fadecLib)
 target_link_libraries("test" fadecLib)
+
+add_library(frvdecLib IMPORTED STATIC)
+ExternalProject_get_property(frvdec BINARY_DIR)
+set_target_properties(frvdecLib PROPERTIES
+        IMPORTED_LOCATION "${BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}frvdec${CMAKE_STATIC_LIBRARY_SUFFIX}")
+add_dependencies(frvdecLib frvdec)
+
+#Make sure frvdecLib is built before translator or test
+add_dependencies(translator frvdecLib version)
+add_dependencies(test frvdecLib version)
+
+target_link_libraries("translator" frvdecLib)
+target_link_libraries("test" frvdecLib)
 
 check_c_compiler_flag(-static-pie HAS_STATIC_PIE)
 

--- a/src/cache/return_stack.c
+++ b/src/cache/return_stack.c
@@ -29,7 +29,7 @@ void rs_emit_push(const t_risc_instr *instr, const register_info *r_info, bool s
     invalidateAllReplacements(r_info);
 
     ///push to return stack
-    t_risc_addr ret_target = instr->addr + 4;
+    t_risc_addr ret_target = instr->addr + instr->size;
 
     t_cache_loc cache_loc;
 
@@ -71,7 +71,7 @@ void rs_emit_push(const t_risc_instr *instr, const register_info *r_info, bool s
 
     err |= fe_enc64(&current, FE_MOV32rm, FE_AX, FE_MEM_ADDR((uint64_t) &rs_front));    //get front
     err |= fe_enc64(&current, FE_MOV64rm, FE_DX, FE_MEM_ADDR((intptr_t) &r_stack));     //get base
-    err |= fe_enc64(&current, FE_MOV64ri, FE_CX, instr->addr + 4);                      //risc return addr
+    err |= fe_enc64(&current, FE_MOV64ri, FE_CX, instr->addr + instr->size);            //risc return addr
     err |= fe_enc64(&current, FE_ADD32ri, FE_AX, 0x10);                                 //increment front by "1" (=16)
     err |= fe_enc64(&current, FE_AND32ri, FE_AX, 0x3f0);                                //mod 64 (*16..)
     err |= fe_enc64(&current, FE_MOV32mr, FE_MEM_ADDR((uint64_t) &rs_front), FE_AX);    //save front

--- a/src/elf/loadElf.c
+++ b/src/elf/loadElf.c
@@ -10,7 +10,25 @@
 #include <env/exit.h>
 #include "loadElf.h"
 
-//Apparently not included in the headers on my version.
+// Older glibc versions don't include these flags
+#ifndef EF_RISCV_RVC
+#define EF_RISCV_RVC                    0x0001
+#endif // !EF_RISCV_RVC
+#ifndef EF_RISCV_FLOAT_ABI
+#define EF_RISCV_FLOAT_ABI              0x0006
+#endif // !EF_RISCV_FLOAT_ABI
+#ifndef EF_RISCV_FLOAT_ABI_SOFT
+#define EF_RISCV_FLOAT_ABI_SOFT         0x0000
+#endif // !EF_RISCV_FLOAT_ABI_SOFT
+#ifndef EF_RISCV_FLOAT_ABI_SINGLE
+#define EF_RISCV_FLOAT_ABI_SINGLE       0x0002
+#endif // !EF_RISCV_FLOAT_ABI_SINGLE
+#ifndef EF_RISCV_FLOAT_ABI_DOUBLE
+#define EF_RISCV_FLOAT_ABI_DOUBLE       0x0004
+#endif // !EF_RISCV_FLOAT_ABI_DOUBLE
+#ifndef EF_RISCV_FLOAT_ABI_QUAD
+#define EF_RISCV_FLOAT_ABI_QUAD         0x0006
+#endif // !EF_RISCV_FLOAT_ABI_QUAD
 #ifndef EF_RISCV_RVE
 #define EF_RISCV_RVE 0x8
 #endif

--- a/src/elf/loadElf.c
+++ b/src/elf/loadElf.c
@@ -93,10 +93,6 @@ t_risc_elf_map_result mapIntoMemory(const char *filePath) {
     bool floatBinary = false;
 
     //Check for not supported ABI Flags
-    if (flags & EF_RISCV_RVC) {
-        critical_not_yet_implemented("C ABI is not yet supported");
-        incompatible = true;
-    }
     if (flags & EF_RISCV_FLOAT_ABI_QUAD || flags & EF_RISCV_FLOAT_ABI_DOUBLE || flags & EF_RISCV_FLOAT_ABI_SINGLE) {
         floatBinary = true;
     }

--- a/src/gen/translate.c
+++ b/src/gen/translate.c
@@ -450,14 +450,15 @@ int parse_block(t_risc_addr risc_addr, t_risc_instr *parse_buf, int maxCount, co
                             //printf("AUIPC + JALR: %p\n", risc_addr);
 
                             //check if pop will happen
-                            if ((parse_buf[parse_pos].reg_src_1 == x1 || parse_buf[parse_pos].reg_src_1 == x5) &&
+                            bool is_ret = (parse_buf[parse_pos].reg_src_1 == x1 || parse_buf[parse_pos].reg_src_1 == x5);
+                            if (is_ret &&
                                     parse_buf[parse_pos].reg_src_1 != parse_buf[parse_pos].reg_dest) {
                                 log_asm_out("---------WRONG POP JALR------------\n");
                             }
 
                             ///1: recursively translate return addr (+4)
                             //dead ends could arise here
-                            {
+                            if (is_ret) {
                                 t_risc_addr ret_target = risc_addr + parse_buf[parse_pos].size;
                                 t_cache_loc cache_loc = lookup_cache_entry(ret_target);
 

--- a/src/gen/translate.c
+++ b/src/gen/translate.c
@@ -283,7 +283,7 @@ int parse_block(t_risc_addr risc_addr, t_risc_instr *parse_buf, int maxCount, co
                     case FENCE:
                     case FENCE_I:
                         ///ignore get next instruction address
-                        risc_addr += 4;
+                        risc_addr += parse_buf[parse_pos].size;
                         parse_pos--; //decrement for next loop cycle
                         break;
                     case EBREAK : {
@@ -306,7 +306,7 @@ int parse_block(t_risc_addr risc_addr, t_risc_instr *parse_buf, int maxCount, co
                             parse_buf[parse_pos].reg_src_2 = (t_risc_reg) parse_buf[parse_pos].mnem; //save mnem
                             parse_buf[parse_pos].mnem = MANUAL_CSRR; //set different mnem for different dispatch
                         }
-                        risc_addr += 4;
+                        risc_addr += parse_buf[parse_pos].size;
                         instructions_in_block++;
                         break;
                     }
@@ -356,7 +356,7 @@ int parse_block(t_risc_addr risc_addr, t_risc_instr *parse_buf, int maxCount, co
                             ///2: recursively translate return addr (+4)
                             //dead ends could arise here
                             {
-                                t_risc_addr ret_target = risc_addr + 4;
+                                t_risc_addr ret_target = risc_addr + parse_buf[parse_pos].size;
                                 t_cache_loc cache_loc = lookup_cache_entry(ret_target);
 
                                 if (cache_loc == UNSEEN_CODE) {
@@ -408,7 +408,8 @@ int parse_block(t_risc_addr risc_addr, t_risc_instr *parse_buf, int maxCount, co
                                 x0,
                                 x0,
                                 parse_buf[parse_pos].reg_dest,
-                                {{4}}
+                                {{parse_buf[parse_pos].size}},
+                                parse_buf[parse_pos].size
                         };
 
                         instructions_in_block++;
@@ -427,7 +428,7 @@ int parse_block(t_risc_addr risc_addr, t_risc_instr *parse_buf, int maxCount, co
                             ///1: recursively translate return addr (+4)
                             //dead ends could arise here
                             {
-                                t_risc_addr ret_target = risc_addr + 4;
+                                t_risc_addr ret_target = risc_addr + parse_buf[parse_pos].size;
                                 t_cache_loc cache_loc = lookup_cache_entry(ret_target);
 
                                 if (cache_loc == UNSEEN_CODE) {
@@ -457,7 +458,7 @@ int parse_block(t_risc_addr risc_addr, t_risc_instr *parse_buf, int maxCount, co
                             ///1: recursively translate return addr (+4)
                             //dead ends could arise here
                             {
-                                t_risc_addr ret_target = risc_addr + 4;
+                                t_risc_addr ret_target = risc_addr + parse_buf[parse_pos].size;
                                 t_cache_loc cache_loc = lookup_cache_entry(ret_target);
 
                                 if (cache_loc == UNSEEN_CODE) {
@@ -472,7 +473,7 @@ int parse_block(t_risc_addr risc_addr, t_risc_instr *parse_buf, int maxCount, co
                             ///2: recursively translate target
                             {
                                 t_risc_addr target =
-                                        (risc_addr - 4) + parse_buf[parse_pos - 1].imm + parse_buf[parse_pos].imm;
+                                        parse_buf[parse_pos - 1].addr + parse_buf[parse_pos - 1].imm + parse_buf[parse_pos].imm;
 
                                 t_cache_loc cache_loc = lookup_cache_entry(target);
 
@@ -513,7 +514,7 @@ int parse_block(t_risc_addr risc_addr, t_risc_instr *parse_buf, int maxCount, co
                 ///no jump or branch -> continue fetching
             default: {
                 ///next instruction address
-                risc_addr += 4;
+                risc_addr += parse_buf[parse_pos].size;
                 instructions_in_block++;
             }
         }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -75,6 +75,7 @@ int32_t parse_instruction(t_risc_instr *p_instr_struct) {
     log_asm_in("Parsing 0x%x at %p\n", raw_instr, (void *) p_instr_struct->addr);
 
     //fill basic struct
+    p_instr_struct->size = 4;
     p_instr_struct->reg_dest = (t_risc_reg) extract_rd(raw_instr);
     p_instr_struct->reg_src_1 = (t_risc_reg) extract_rs1(raw_instr);
     p_instr_struct->reg_src_2 = INVALID_REG; //Set to not used value for analyzer to work correctly

--- a/src/runtime/emulateEcall.c
+++ b/src/runtime/emulateEcall.c
@@ -119,7 +119,7 @@ static size_t syscall6(int syscall_number, size_t a1, size_t a2, size_t a3,
 __attribute__((force_align_arg_pointer))
 void emulate_ecall(t_risc_addr addr, t_risc_reg_val *registerValues) {
     ///Increment PC, if the syscall needs to modify it just overwrite it in the specific branch.
-    registerValues[pc] = addr + 4;
+    registerValues[pc] = addr + 4; /// XXX-C!
     switch (registerValues[a7]) {
         case 17: //getcwd
         {

--- a/src/runtime/emulateEcall.c
+++ b/src/runtime/emulateEcall.c
@@ -4,6 +4,7 @@
 
 #include <asm/stat.h>
 #include <linux/mman.h>
+#include <linux/utsname.h>
 #include <common.h>
 #include <runtime/register.h>
 #include <elf/loadElf.h>
@@ -356,7 +357,13 @@ void emulate_ecall(t_risc_addr addr, t_risc_reg_val *registerValues) {
         case 160: //uname
         {
             log_syscall("Emulate syscall uname (160)...\n");
+            struct new_utsname* buf = (void*) registerValues[a0];
             registerValues[a0] = syscall1(__NR_uname, registerValues[a0]);
+            if (registerValues[a0] == 0) {
+                // Emulate kernel 5.0.0 -- glibc checks kernel versions.
+                if (buf->release[0] <= '4' && buf->release[1] == '.')
+                    memcpy(buf->release, "5.0.0", sizeof "5.0.0");
+            }
         }
             break;
         case 169: //gettimeofday

--- a/src/util/log.c
+++ b/src/util/log.c
@@ -17,9 +17,9 @@ void not_yet_implemented_internal(const char *info, va_list args);
 const char *const translator_version = VERSION;
 
 void not_yet_implemented_internal(const char *info, va_list args) {
-    dprintf(1, "Warning: ");
-    vdprintf(1, info, args);
-    dprintf(1, " - not yet implemented\n");
+    dprintf(2, "Warning: ");
+    vdprintf(2, info, args);
+    dprintf(2, " - not yet implemented\n");
 }
 
 void not_yet_implemented(const char *info, ...) {

--- a/src/util/tools/analyze.c
+++ b/src/util/tools/analyze.c
@@ -49,7 +49,7 @@ struct firstLevel {
 // function to sort a singly linked list using insertion sort
 void insertionSort(t_node **head);
 
-void add_instruction(t_risc_addr addr, uint64_t *mnem_count, uint64_t *reg_count);
+unsigned add_instruction(t_risc_addr addr, uint64_t *mnem_count, uint64_t *reg_count);
 
 void analyze(const char *file_path) {
     log_analyze("Started file analysis...\n");
@@ -81,8 +81,8 @@ void analyze(const char *file_path) {
     }
 
     //loop over full segment
-    for (t_risc_addr addr = startAddr; addr < endAddr; addr += 4) {
-        add_instruction(addr, mnem, reg);
+    for (t_risc_addr addr = startAddr; addr < endAddr; ) {
+        addr += add_instruction(addr, mnem, reg);
     }
 
     log_analyze("Done reading file.\n");
@@ -302,7 +302,7 @@ t_node *getOrAllocateNode() {
 }
 
 
-void add_instruction(t_risc_addr addr, uint64_t *mnem_count, uint64_t *reg_count) {
+unsigned add_instruction(t_risc_addr addr, uint64_t *mnem_count, uint64_t *reg_count) {
     prev = cur;
     cur = (t_risc_instr) {0};
     cur.addr = addr;
@@ -378,7 +378,7 @@ void add_instruction(t_risc_addr addr, uint64_t *mnem_count, uint64_t *reg_count
         curNode->count++;
     }
 
-
+    return cur.size;
 }
 
 // Function to insert a given node in a sorted linked list

--- a/src/util/typedefs.h
+++ b/src/util/typedefs.h
@@ -418,6 +418,7 @@ typedef struct {
             uint32_t rounding_mode;
         };
     };
+    uint8_t size;
 } t_risc_instr;
 
 /**


### PR DESCRIPTION
This PR is a mixture of things; feel free to cherry-pick single commits. Most notable, the RV-C extension is supported, RIA-JIT runs on enterprise-y systems, and some minor bug fixes when running benchmarks are included. There are two spots left where the instruction size of 4 is still hard-coded; but I'm not sure how to properly fix these. In any case, this doesn't seem to impact the benchmarks I tested.